### PR TITLE
feat: add lb-tabs component

### DIFF
--- a/uni_modules/LD-LBUI/components/lb-tabs/lb-tabs.uvue
+++ b/uni_modules/LD-LBUI/components/lb-tabs/lb-tabs.uvue
@@ -1,35 +1,229 @@
 <template>
-	<view class="lb-tabs">
-		<scroll-view :scroll-into-view="scrollIntoViewId" scroll-with-animation :show-scrollbar="false"
-			direction="horizontal">
-			<view class="lb-tabs__nav-inner" ref="navRef">
-				<view v-for="(pane,idx) in panes" :key="pane.id" :id="`lb-tab-${uid}-${idx}`" class="lb-tabs__tab">
-				</view>
-			</view>
-		</scroll-view>
-	</view>
+        <view class="lb-tabs" :class="[sizeClass,typeClass]" :style="rootStyle">
+                <scroll-view :scroll-into-view="scrollIntoViewId" scroll-with-animation :show-scrollbar="false"
+                        direction="horizontal">
+                        <view :id="navId" class="lb-tabs__nav-inner" ref="navRef">
+                                <view v-for="(pane,idx) in panes" :key="pane.id" :id="`lb-tab-${uid}-${idx}`"
+                                        class="lb-tabs__tab" :class="{'is-active':activeIndex===idx}" @tap="onTabTap(idx)">
+                                        {{pane.label}}
+                                </view>
+                                <view class="lb-tabs__bar" :style="barStyle"></view>
+                        </view>
+                </scroll-view>
+                <swiper v-if="swipeable" class="lb-tabs__content" :current="activeIndex" @change="onSwiperChange">
+                        <swiper-item v-for="(pane,idx) in panes" :key="pane.id">
+                                <view class="lb-tabs__pane">
+                                        <component :is="pane.vnode" v-if="!lazy || pane.loaded"></component>
+                                </view>
+                        </swiper-item>
+                </swiper>
+                <view v-else class="lb-tabs__content">
+                        <view v-for="(pane,idx) in panes" :key="pane.id" v-show="activeIndex===idx" class="lb-tabs__pane">
+                                <component :is="pane.vnode" v-if="!lazy || pane.loaded"></component>
+                        </view>
+                </view>
+        </view>
 </template>
 
 <script setup lang="uts">
-	const modelValue = defineModel()
-	const props = defineProps<{
-		type ?: 'line' | 'card' | 'segment'
-		size ?: 'sm' | 'md' | 'lg'
-		theme ?: string
-		swipeable ?: boolean
-		lazy ?: boolean
-	}>({
-		type: 'line',
-		size: 'md',
-		theme: 'primary',
-		swipeable: true,
-		lazy: true
-	})
-	
-	const emit = defineEmits(['change'])
-	
+        const modelValue = defineModel<number>()
+        const props = defineProps<{
+                type ?: 'line' | 'card' | 'segment'
+                size ?: 'sm' | 'md' | 'lg'
+                theme ?: string
+                swipeable ?: boolean
+                lazy ?: boolean
+        }>({
+                type: 'line',
+                size: 'md',
+                theme: 'primary',
+                swipeable: true,
+                lazy: true
+        })
+
+        const emit = defineEmits(['change'])
+
+        interface TabPane {
+                id : string
+                label : string
+                vnode : any
+                loaded : boolean
+        }
+
+        const uid = Math.random().toString(36).slice(2)
+        const navId = `lb-tabs-nav-${uid}`
+        const navRef = ref()
+        const scrollIntoViewId = ref('')
+        const barStyle = ref<any>({})
+
+        const slots = useSlots()
+        const panes = ref<Array<TabPane>>([])
+
+        const activeIndex = computed({
+                get : () : number => modelValue.value ?? 0,
+                set : (val : number) => {
+                        modelValue.value = val
+                }
+        })
+
+        function initPanes() {
+                const list = slots.default ? slots.default() : []
+                panes.value = list.map((vnode : any, idx : number) => {
+                        const props : any = vnode.props || {}
+                        return {
+                                id: props.id || String(idx),
+                                label: props.label || props.title || `Tab ${idx + 1}`,
+                                vnode,
+                                loaded: !props.lazy && !lazy ? true : idx === activeIndex.value
+                        } as TabPane
+                })
+        }
+        initPanes()
+
+        const rootStyle = computed(() => ({
+                '--active-color': `var(--${props.theme}-base)`
+        }))
+
+        const sizeClass = computed(() => `size--${props.size}`)
+        const typeClass = computed(() => `type--${props.type}`)
+
+        function onTabTap(idx : number) {
+                if (idx === activeIndex.value) return
+                activeIndex.value = idx
+                emit('change', idx)
+        }
+
+        function onSwiperChange(e : any) {
+                activeIndex.value = e.detail.current
+                emit('change', activeIndex.value)
+        }
+
+        function updateBar() {
+                nextTick(() => {
+                        const q = uni.createSelectorQuery()
+                        q.select(`#${navId}`).boundingClientRect((navRect : any) => {
+                                q.select(`#lb-tab-${uid}-${activeIndex.value}`).boundingClientRect((tabRect : any) => {
+                                        if (!navRect || !tabRect) return
+                                        const left = tabRect.left - navRect.left
+                                        barStyle.value = {
+                                                width: `${tabRect.width}px`,
+                                                transform: `translateX(${left}px)`
+                                        }
+                                }).exec()
+                        }).exec()
+                })
+        }
+
+        watch(activeIndex, (idx : number) => {
+                scrollIntoViewId.value = `lb-tab-${uid}-${idx}`
+                if (panes.value[idx]) panes.value[idx].loaded = true
+                updateBar()
+        })
+
+        onMounted(() => {
+                updateBar()
+        })
+
+        const swipeable = computed(() => props.swipeable)
+        const lazy = props.lazy
+
 </script>
 
-<style>
+<style lang="scss" scoped>
+        .lb-tabs {
+                display: flex;
+                flex-direction: column;
+        }
+
+        .lb-tabs__nav-inner {
+                display: flex;
+                flex-direction: row;
+                position: relative;
+        }
+
+        .lb-tabs__tab {
+                padding: var(--spacing-md) var(--spacing-lg);
+                color: var(--gray-500);
+                white-space: nowrap;
+        }
+
+        .lb-tabs__tab.is-active {
+                color: var(--active-color);
+        }
+
+        .lb-tabs__bar {
+                position: absolute;
+                bottom: 0;
+                height: 4rpx;
+                background-color: var(--active-color);
+                transition: width .3s ease, transform .3s ease;
+        }
+
+        .lb-tabs__content {
+                flex: 1;
+        }
+
+        .lb-tabs__pane {
+                width: 100%;
+                height: 100%;
+        }
+
+        .lb-tabs.size--sm .lb-tabs__tab {
+                padding: var(--spacing-sm) var(--spacing-md);
+                font-size: var(--font-size-sm);
+        }
+
+        .lb-tabs.size--md .lb-tabs__tab {
+                padding: var(--spacing-md) var(--spacing-lg);
+                font-size: var(--font-size-md);
+        }
+
+        .lb-tabs.size--lg .lb-tabs__tab {
+                padding: var(--spacing-lg) var(--spacing-xl);
+                font-size: var(--font-size-lg);
+        }
+
+        .lb-tabs.type--card .lb-tabs__nav-inner {
+                border-bottom: 1px solid var(--gray-200);
+        }
+
+        .lb-tabs.type--card .lb-tabs__tab {
+                border: 1px solid var(--gray-200);
+                border-bottom: none;
+                margin-right: -1px;
+                border-top-left-radius: var(--border-radius-md);
+                border-top-right-radius: var(--border-radius-md);
+        }
+
+        .lb-tabs.type--card .lb-tabs__tab.is-active {
+                background-color: #fff;
+                color: var(--active-color);
+                border-color: var(--active-color);
+        }
+
+        .lb-tabs.type--card .lb-tabs__bar {
+                display: none;
+        }
+
+        .lb-tabs.type--segment {
+                background-color: var(--gray-100);
+                padding: var(--spacing-xs);
+                border-radius: var(--border-radius-md);
+        }
+
+        .lb-tabs.type--segment .lb-tabs__tab {
+                padding: var(--spacing-sm) var(--spacing-md);
+                border-radius: var(--border-radius-md);
+                margin-right: var(--spacing-sm);
+        }
+
+        .lb-tabs.type--segment .lb-tabs__tab.is-active {
+                background-color: var(--active-color);
+                color: #fff;
+        }
+
+        .lb-tabs.type--segment .lb-tabs__bar {
+                display: none;
+        }
 
 </style>


### PR DESCRIPTION
## Summary
- implement `lb-tabs` component with scrollable nav, swipeable content, and lazy rendering
- style tabs with size, type, and theme variants using existing tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d4ca1a2c8321a8f7330ee24ebb26